### PR TITLE
Fix duplicate door drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Fixed `/reload` breaking some functionality.
 - Fixed lang overrides not being respected in some cases.
 - Added some config options to revert the loot table and recipe changes by the mod.
+- Fixed mapped doors dropping duplicate items when broken.

--- a/buildSrc/src/main/kotlin/common.gradle.kts
+++ b/buildSrc/src/main/kotlin/common.gradle.kts
@@ -3,6 +3,15 @@ plugins {
     idea
 }
 
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.4")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
 version = "${prop("mod.version")}+${dep("minecraft")}-$loaderName"
 base.archivesName = prop("mod.id")
 

--- a/src/main/java/dev/tazer/clutternomore/common/CHooks.java
+++ b/src/main/java/dev/tazer/clutternomore/common/CHooks.java
@@ -15,6 +15,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
@@ -36,11 +37,33 @@ public class CHooks {
     ) {
         Item item = state.getBlock().asItem();
         if (ShapeMap.isShape(item) && ClutterNoMore.STARTUP_CONFIG.INHERIT_LOOT_TABLES.value()) {
+            if (isNonLowerMultiBlockPart(state)) return old;
+
             LootParams.Builder lootparams$builder = (new LootParams.Builder(level)).withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(pos)).withParameter(LootContextParams.TOOL, tool).withOptionalParameter(LootContextParams.THIS_ENTITY, entity).withOptionalParameter(LootContextParams.BLOCK_ENTITY, blockEntity);
             BlockState newState = Block.byItem(ShapeMap.getParent(item)).defaultBlockState();
+            for (Property<?> property : state.getProperties()) {
+                newState = copyProperty(state, newState, property);
+            }
             return newState.getDrops(lootparams$builder);
         }
 
         return old;
+    }
+
+    private static boolean isNonLowerMultiBlockPart(BlockState state) {
+        for (Property<?> property : state.getProperties()) {
+            if (MultiBlockLootPart.isNonLower(property.getName(), propertyValueName(state, property))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static <T extends Comparable<T>> String propertyValueName(BlockState state, Property<T> property) {
+        return property.getName(state.getValue(property));
+    }
+
+    private static <T extends Comparable<T>> BlockState copyProperty(BlockState source, BlockState target, Property<T> property) {
+        return target.hasProperty(property) ? target.setValue(property, source.getValue(property)) : target;
     }
 }

--- a/src/main/java/dev/tazer/clutternomore/common/MultiBlockLootPart.java
+++ b/src/main/java/dev/tazer/clutternomore/common/MultiBlockLootPart.java
@@ -1,0 +1,9 @@
+package dev.tazer.clutternomore.common;
+
+final class MultiBlockLootPart {
+    private MultiBlockLootPart() {}
+
+    static boolean isNonLower(String property, String value) {
+        return (property.equals("half") || property.equals("third")) && (value.equals("middle") || value.equals("upper"));
+    }
+}

--- a/src/test/java/dev/tazer/clutternomore/common/CHooksTest.java
+++ b/src/test/java/dev/tazer/clutternomore/common/CHooksTest.java
@@ -1,0 +1,24 @@
+package dev.tazer.clutternomore.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CHooksTest {
+    @Test
+    void suppressesOnlyNonLowerMultiBlockParts() {
+        assertFalse(MultiBlockLootPart.isNonLower("half", "lower"));
+        assertTrue(MultiBlockLootPart.isNonLower("half", "upper"));
+
+        assertFalse(MultiBlockLootPart.isNonLower("third", "lower"));
+        assertTrue(MultiBlockLootPart.isNonLower("third", "middle"));
+        assertTrue(MultiBlockLootPart.isNonLower("third", "upper"));
+    }
+
+    @Test
+    void ignoresUnrelatedPropertiesAndValues() {
+        assertFalse(MultiBlockLootPart.isNonLower("facing", "upper"));
+        assertFalse(MultiBlockLootPart.isNonLower("half", "top"));
+    }
+}


### PR DESCRIPTION
## Summary

- Preserve compatible block-state properties when evaluating inherited parent loot tables.
- Prevent middle and upper multi-block door segments from producing duplicate drops.
- Add deterministic tests covering vanilla door halves and Dramatic Doors’ three-part doors.
- Add the required JUnit test configuration and changelog entry.

## Testing

```
./gradlew :1.21.1-neoforge:test --tests "dev.tazer.clutternomore.common.CHooksTest" --no-daemon
```

Result: 2 tests passed, 0 failures.

Closes #65.